### PR TITLE
Add lualine statusline for neovim

### DIFF
--- a/nvim/.config/nvim/lua/plugins/init.lua
+++ b/nvim/.config/nvim/lua/plugins/init.lua
@@ -13,6 +13,7 @@ return {
         native_lsp = { enabled = true },
         telescope = { enabled = true },
         treesitter = true,
+        lualine = true,
       },
     },
   },
@@ -225,6 +226,46 @@ return {
       { "<leader>4", function() require("harpoon"):list():select(4) end, desc = "Harpoon 4" },
     },
     opts = {},
+  },
+
+  -- Statusline
+  {
+    "nvim-lualine/lualine.nvim",
+    event = "VeryLazy",
+    opts = {
+      options = {
+        globalstatus = true,
+        component_separators = "",
+        section_separators = "",
+        disabled_filetypes = { statusline = { "lazy" } },
+      },
+      sections = {
+        lualine_a = {
+          { "mode", fmt = function(s) return s:sub(1, 1) end },
+        },
+        lualine_b = {
+          { "branch", icon = "" },
+        },
+        lualine_c = {
+          { "filename", path = 1, symbols = { modified = " ●", readonly = " ", unnamed = "[No Name]" } },
+          {
+            "diagnostics",
+            symbols = { error = "E:", warn = "W:", info = "I:", hint = "H:" },
+          },
+        },
+        lualine_x = { "filetype" },
+        lualine_y = { "progress" },
+        lualine_z = { "location" },
+      },
+      inactive_sections = {
+        lualine_a = {},
+        lualine_b = {},
+        lualine_c = { { "filename", path = 1, symbols = { modified = " ●", readonly = " " } } },
+        lualine_x = { "location" },
+        lualine_y = {},
+        lualine_z = {},
+      },
+    },
   },
 
   -- Surround


### PR DESCRIPTION
Minimal, wincent-inspired statusline using lualine.nvim that auto-adapts to all configured colorschemes (catppuccin, tokyonight, rose-pine, gruvbox, nord). Uses no separators and text-only diagnostic symbols to match the clean tmux status bar aesthetic.