### PR TITLE
feat(ai): lazy-install agent skills on first launch

### DIFF
--- a/ai/.claude/.gitignore
+++ b/ai/.claude/.gitignore
@@ -7,3 +7,12 @@
 /statsig
 /todos
 __store.db
+
+# Skills auto-installed on first `sb claude` (see ai/README.md).
+# `~/.claude/skills/` is folded by stow into this directory, so any
+# new skill written by the installer lands here. Keep the three
+# locally-authored skills tracked; ignore everything else.
+/skills/*
+!/skills/commit/
+!/skills/jujutsu/
+!/skills/research-repo/

--- a/ai/.pi/agent/.gitignore
+++ b/ai/.pi/agent/.gitignore
@@ -6,3 +6,6 @@
 /npm/
 /.last_session
 __store.db
+
+# Skills auto-installed on first `sb pi` (see ai/README.md).
+/skills/

--- a/ai/README.md
+++ b/ai/README.md
@@ -50,3 +50,38 @@ starting points if you need to recreate a config.
 
 All agents share sandbox profiles under `~/.config/nono/` — launch via
 `sb claude` / `sb codex` / `sb opencode` / `sb pi` to enforce.
+
+## Skills
+
+Three local skills are tracked here under `.claude/skills/`:
+
+- `commit/` — git/jj commit creation
+- `research-repo/` — `gh`-based GitHub investigation
+- `jujutsu/` — `jj` usage
+
+Everything else is pulled from upstream
+([`mattpocock/skills`](https://github.com/mattpocock/skills) plus
+`find-skills` from `vercel-labs/skills`) **on first launch** of each
+agent. The fish wrappers under
+`shell/.config/fish/functions/{claude,pi,codex,opencode}.fish` call
+the shared helper `_ai_ensure_skills <agent>`, which runs
+`npx skills@latest add ... --copy` once and writes a sentinel at
+`~/.cache/dotfiles/skills.<agent>.installed` so subsequent launches
+skip the install.
+
+Only fish-resolved invocations are wrapped — `sb claude` execs
+`nono run -- claude` and nono spawns the binary directly, bypassing
+the fish function. Run the agent once directly (`claude`, `pi`, etc.)
+to trigger the install; sandboxed launches afterwards reuse the
+result.
+
+Stow folds the per-agent skill directories back into this repo, so
+auto-installed trees physically land in `ai/.claude/skills/` and
+`ai/.pi/agent/skills/`; both are filtered out via `.gitignore` and
+never get committed.
+
+To force a refresh from upstream:
+
+```sh
+rm ~/.cache/dotfiles/skills.*.installed   # next sb launch reinstalls
+```

--- a/shell/.config/fish/functions/_ai_ensure_skills.fish
+++ b/shell/.config/fish/functions/_ai_ensure_skills.fish
@@ -1,0 +1,17 @@
+function _ai_ensure_skills -d "Install agent skills on first launch (idempotent)"
+    set -l skills_agent $argv[1]
+    set -l sentinel "$HOME/.cache/dotfiles/skills.$skills_agent.installed"
+    test -f $sentinel; and return 0
+    command -q npx; or return 0
+
+    printf '\033[33m(first launch: installing %s skills...)\033[0m\n' $skills_agent >&2
+    npx --yes skills@latest add mattpocock/skills \
+        --global --agent $skills_agent --skill '*' -y --copy
+    or return $status
+    npx --yes skills@latest add vercel-labs/skills \
+        --global --agent $skills_agent --skill find-skills -y --copy
+    or return $status
+
+    mkdir -p (dirname $sentinel)
+    touch $sentinel
+end

--- a/shell/.config/fish/functions/claude.fish
+++ b/shell/.config/fish/functions/claude.fish
@@ -4,6 +4,8 @@ function claude --wraps claude --description "claude-code: auto-install via offi
         curl -fsSL https://claude.ai/install.sh | bash -s -- latest
     end
 
+    _ai_ensure_skills claude-code
+
     if set -q TMUX
         tmux rename-window claude
         tmux set-window-option allow-rename off

--- a/shell/.config/fish/functions/codex.fish
+++ b/shell/.config/fish/functions/codex.fish
@@ -1,0 +1,4 @@
+function codex --wraps codex --description "codex wrapper that lazy-installs skills on first launch"
+    _ai_ensure_skills codex
+    command codex $argv
+end

--- a/shell/.config/fish/functions/opencode.fish
+++ b/shell/.config/fish/functions/opencode.fish
@@ -1,0 +1,4 @@
+function opencode --wraps opencode --description "opencode wrapper that lazy-installs skills on first launch"
+    _ai_ensure_skills opencode
+    command opencode $argv
+end

--- a/shell/.config/fish/functions/pi.fish
+++ b/shell/.config/fish/functions/pi.fish
@@ -8,6 +8,8 @@ function pi --wraps pi --description "pi.dev coding agent: auto-install via npm 
         npm install -g @mariozechner/pi-coding-agent
     end
 
+    _ai_ensure_skills pi
+
     if set -q TMUX
         tmux rename-window pi
         tmux set-window-option allow-rename off

--- a/shell/.config/fish/functions/sb.fish
+++ b/shell/.config/fish/functions/sb.fish
@@ -2,7 +2,7 @@ function sb -d "Run a command inside a nono sandbox"
     if test (count $argv) -eq 0
         echo "Usage: sb <command> [args...]" >&2
         echo "Runs <command> in a nono sandbox using a matching profile." >&2
-        echo "Known profiles: claude, codex, opencode" >&2
+        echo "Known profiles: claude, codex, opencode, pi" >&2
         return 1
     end
 


### PR DESCRIPTION
Pulls Matt Pocock's agent skills (and find-skills) from upstream the first time each fish-resolved agent is launched, instead of vendoring them into the repo.